### PR TITLE
Update authentication API to conform to application API shape

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -12,7 +12,7 @@ gem 'pg', '~> 1.1'
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.7'
+gem 'jbuilder', '~> 2.11.2'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -197,7 +197,7 @@ DEPENDENCIES
   byebug
   devise (~> 4.8)
   devise_token_auth (~> 1.2)
-  jbuilder (~> 2.7)
+  jbuilder (~> 2.11.2)
   listen (~> 3.3)
   pg (~> 1.1)
   puma (~> 5.0)

--- a/backend/app/controllers/auth/registrations_controller.rb
+++ b/backend/app/controllers/auth/registrations_controller.rb
@@ -2,22 +2,33 @@
 
 module Auth
   class RegistrationsController < DeviseTokenAuth::RegistrationsController
+    include AuthHelper
+
+    private
+
     def render_create_success
-      render json: {
-        status: 'success',
-        payload: { data: resource_data },
-        messages: [],
-        errors: []
-      }
+      show_success_message("Successfully registered with username '#{@resource.username}'!")
+      render 'auth/user', status: :created
     end
 
     def render_create_error
-      render json: {
-        status: 'error',
-        payload: { data: resource_data },
-        messages: [],
-        errors: resource_errors
-      }, status: :unprocessable_entity
+      show_error_message("Unable to register with username '#{@resource.username}'")
+      render 'auth/user', status: :unprocessable_entity
+    end
+
+    def render_update_success
+      show_success_message('Successfully updated profile!')
+      render 'auth/user', status: :ok
+    end
+
+    def render_update_error
+      show_error_message('Unable to update profile')
+      render 'auth/user', status: :unprocessable_entity
+    end
+
+    def render_destroy_success
+      show_success_message("Successfully deleted user with username '#{@resource.username}'!")
+      render 'layouts/empty', status: :ok
     end
   end
 end

--- a/backend/app/controllers/auth/sessions_controller.rb
+++ b/backend/app/controllers/auth/sessions_controller.rb
@@ -2,20 +2,18 @@
 
 module Auth
   class SessionsController < DeviseTokenAuth::SessionsController
+    include AuthHelper
+
+    private
+
     def render_create_success
-      render json: {
-        payload: { data: resource_data(resource_json: @resource.token_validation_response) },
-        messages: [],
-        errors: []
-      }
+      show_success_message("Welcome, #{@resource.username}!")
+      render 'auth/user', status: :created
     end
 
-    def render_create_error_bad_credentials
-      render json: {
-        payload: { data: nil },
-        messages: [],
-        errors: [I18n.t('devise_token_auth.sessions.bad_credentials')]
-      }, status: :unauthorized
+    def render_destroy_success
+      show_success_message('Successfully logged out!')
+      render 'layouts/empty', status: :ok
     end
   end
 end

--- a/backend/app/controllers/concerns/auth_helper.rb
+++ b/backend/app/controllers/concerns/auth_helper.rb
@@ -4,6 +4,6 @@ module AuthHelper
   def render_error(status, message, _data = nil)
     @errors = message
     show_error_message(message)
-    render 'auth/user', status: status
+    render 'layouts/empty', status: status
   end
 end

--- a/backend/app/controllers/concerns/auth_helper.rb
+++ b/backend/app/controllers/concerns/auth_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module AuthHelper
+  def render_error(status, message, _data = nil)
+    @errors = message
+    show_error_message(message)
+    render 'auth/user', status: status
+  end
+end

--- a/backend/app/views/auth/user.json.jbuilder
+++ b/backend/app/views/auth/user.json.jbuilder
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-json.key_format! camelize: :lower
-
 # The Devise controllers make use of @resource to store the user information.
 json.data do
   json.id @resource.id

--- a/backend/app/views/auth/user.json.jbuilder
+++ b/backend/app/views/auth/user.json.jbuilder
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+json.key_format! camelize: :lower
+
+# The Devise controllers make use of @resource to store the user information.
+json.data do
+  json.id @resource.id
+  json.username @resource.username
+  json.displayName @resource.display_name
+end

--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -19,7 +19,7 @@ Devise.setup do |config|
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
-  # config.parent_controller = 'DeviseController'
+  config.parent_controller = 'ApplicationController'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "axios": "^0.22.0",
-    "humps": "^2.0.1",
     "immer": "^9.0.6",
     "js-cookie": "^3.0.1",
     "react": "^17.0.2",

--- a/frontend/src/api/base.ts
+++ b/frontend/src/api/base.ts
@@ -3,9 +3,7 @@ import axios, {
   AxiosPromise,
   AxiosRequestConfig,
   AxiosResponse,
-  AxiosTransformer,
 } from 'axios';
-import humps from 'humps';
 import Cookies from 'js-cookie';
 import {
   ApiPromise,
@@ -94,15 +92,6 @@ class BaseAPI {
   private static initialiseClient() {
     const client = axios.create({
       baseURL: process.env.REACT_APP_SERVER_BASE_URL,
-      transformResponse: [
-        ...(axios.defaults.transformResponse as AxiosTransformer[]),
-        (
-          data
-        ): any => // eslint-disable-line @typescript-eslint/no-explicit-any
-          humps.camelizeKeys(data, function (key, convert) {
-            return /^[A-Z0-9_]+$/.test(key) ? key : convert(key);
-          }), // takes care of case issues, skips all caps
-      ],
     });
 
     client.interceptors.request.use(

--- a/frontend/src/api/base.ts
+++ b/frontend/src/api/base.ts
@@ -92,6 +92,10 @@ class BaseAPI {
   private static initialiseClient() {
     const client = axios.create({
       baseURL: process.env.REACT_APP_SERVER_BASE_URL,
+      headers: {
+        accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
     });
 
     client.interceptors.request.use(

--- a/frontend/src/pages/registration/RegistrationPage.tsx
+++ b/frontend/src/pages/registration/RegistrationPage.tsx
@@ -111,7 +111,7 @@ const RegistrationPage: React.FC = () => {
                   fullWidth
                   name="passwordConfirmation"
                   label="Confirm Password"
-                  type="passwordConfirmation"
+                  type="password"
                   id="passwordConfirmation"
                   error={!!errors.passwordConfirmation}
                   helperText={errors.passwordConfirmation?.message}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6046,11 +6046,6 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-humps@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
-  integrity sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=
-
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
To verify that all possible JSON output has been overridden, `Ctrl-F` for `def render` in `DeviseTokenAuth::RegistrationsController` and `DeviseTokenAuth::SessionsController`. Note that most of them call `render_error` which is overridden in `app/controllers/concerns/auth_helper.rb` as a concern since it is used across Devise controllers.

Also removed Axios interceptor for transforming snake case to camel case in frontend.