### PR TITLE
Fix duplicate key error

### DIFF
--- a/frontend/src/pages/category/CategoryPage.tsx
+++ b/frontend/src/pages/category/CategoryPage.tsx
@@ -9,6 +9,7 @@ import { useParams, Link } from 'react-router-dom';
 import { RootState } from 'store';
 import { getCategory } from 'store/categories/selectors';
 import { loadAllChallenges } from 'store/challenges/operations';
+import { loadCategory } from 'store/categories/operations';
 import { getChallengeList } from 'store/challenges/selectors';
 import { getHeadingFromCategory } from 'utils/naming';
 import Tabs from '@mui/material/Tabs';
@@ -75,6 +76,7 @@ const ExplorePage: React.FC = () => {
   )!;
 
   useEffect(() => {
+    dispatch(loadCategory(Number(categoryId)));
     dispatch(loadAllChallenges());
   }, []);
 

--- a/frontend/src/store/categories/reducer.ts
+++ b/frontend/src/store/categories/reducer.ts
@@ -5,7 +5,6 @@ import {
   SAVE_CATEGORY,
   SAVE_CATEGORY_LIST,
 } from './types';
-import { CategoryData } from '../../types/categories';
 
 const initialState: CategoriesState = {
   categoryList: [],
@@ -17,15 +16,9 @@ const categoriesReducer = produce(
     switch (action.type) {
       case SAVE_CATEGORY_LIST: {
         draft.categoryList = action.categoryList;
-        action.categoryList.forEach(
-          (category: CategoryData) => (draft.categories[category.id] = category)
-        );
         break;
       }
       case SAVE_CATEGORY: {
-        if (!draft.categoryList.includes(action.category)) {
-          draft.categoryList.push(action.category);
-        }
         draft.categories[action.category.id] = action.category;
         break;
       }

--- a/frontend/src/store/challenges/reducer.ts
+++ b/frontend/src/store/challenges/reducer.ts
@@ -6,7 +6,6 @@ import {
   SAVE_CHALLENGE,
   SAVE_CHALLENGE_LIST,
 } from './types';
-import { ChallengeListData } from '../../types/challenges';
 
 const initialState: ChallengesState = {
   challengeList: [],
@@ -21,16 +20,10 @@ const challengesReducer = produce(
         break;
       }
       case SAVE_CHALLENGE: {
-        if (!draft.challengeList.includes(action.challenge)) {
-          draft.challengeList.push(action.challenge);
-        }
         draft.challenges[action.challenge.id] = action.challenge;
         break;
       }
       case REMOVE_CHALLENGE: {
-        draft.challengeList = draft.challengeList.filter(
-          (challenge: ChallengeListData) => challenge.id !== action.challengeId
-        );
         delete draft.challenges[action.challengeId];
         break;
       }

--- a/frontend/src/store/tasks/reducer.ts
+++ b/frontend/src/store/tasks/reducer.ts
@@ -6,7 +6,6 @@ import {
   TaskActions,
   TasksState,
 } from './types';
-import { TaskData, TaskListData } from '../../types/tasks';
 
 const initialState: TasksState = {
   taskList: [],
@@ -17,22 +16,13 @@ const tasksReducer = produce((draft: TasksState, action: TaskActions) => {
   switch (action.type) {
     case SAVE_TASK_LIST: {
       draft.taskList = action.taskList;
-      action.taskList.forEach(
-        (task: TaskData) => (draft.tasks[task.id] = task)
-      );
       break;
     }
     case SAVE_TASK: {
-      if (!draft.taskList.includes(action.task)) {
-        draft.taskList.push(action.task);
-      }
       draft.tasks[action.task.id] = action.task;
       break;
     }
     case REMOVE_TASK: {
-      draft.taskList = draft.taskList.filter(
-        (task: TaskListData) => task.id !== action.taskId
-      );
       delete draft.tasks[action.taskId];
       break;
     }


### PR DESCRIPTION
To replicate: 
- Head to http://localhost:8000/category/2, then press back. Duplicate key error should appear.

Fixed by modifying the reducers to be less efficient. I think it's better if we're more deliberate in fetching / modifying the store when needed
- Current implementation is quite brittle since it assumes that the `xxxData = xxxListData`