### PR TITLE
Tiny fixes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import {
   HOME_ROUTE,
   privateRoutes,
   publicRoutes,
+  mainRoutes,
   notAuthenticatedRoutes,
 } from './routing/routes';
 import RouteWithRedirect, {
@@ -99,7 +100,7 @@ function App(): JSX.Element {
           </Switch>
         </Container>
       </div>
-      {!notAuthenticatedRoutes
+      {mainRoutes
         .map((route: RouteEntry) => route.path)
         .includes(location.pathname) && <BottomNavigationBar />}
       <FeedbackOverlay />

--- a/frontend/src/components/category/CategoryHeader.tsx
+++ b/frontend/src/components/category/CategoryHeader.tsx
@@ -56,7 +56,7 @@ const CategoryHeader: React.FC<CategoryHeaderProps> = (props) => {
     >
       <div className={classes.overlayText}>
         <Typography variant="h5">I want to...</Typography>
-        <Typography variant="h3" sx={{ paddingBottom: '0.5em', fontFamily: 'Frock' }}>{heading}</Typography>
+        <Typography variant="h1" sx={{ paddingBottom: '0.5em', fontFamily: 'Frock' }}>{heading}</Typography>
       </div>
       <img src={headerImage.default} className={classes.backgroundImage} />
     </Box>

--- a/frontend/src/components/home/UserTaskCard.tsx
+++ b/frontend/src/components/home/UserTaskCard.tsx
@@ -76,11 +76,12 @@ const UserTaskCard: React.FC<Props> = ({ userTask }: Props) => {
           {userTask.description}
         </Typography>
         <div className={classes.doneToggle}>
-          <Switch
-            checked={!!userTask.completedAt}
-            disabled={isAfter(new Date(userTask.scheduledFor), new Date())}
-            onChange={handleDoneToggle}
-          />
+          {!isAfter(new Date(userTask.scheduledFor), new Date()) && (
+            <Switch
+              checked={!!userTask.completedAt}
+              onChange={handleDoneToggle}
+            />
+          )}
         </div>
       </div>
     </Card>

--- a/frontend/src/components/home/UserTaskCard.tsx
+++ b/frontend/src/components/home/UserTaskCard.tsx
@@ -49,7 +49,11 @@ const UserTaskCard: React.FC<Props> = ({ userTask }: Props) => {
   const classes = useStyles(userTask);
   const dispatch = useDispatch();
 
-  const status = !!userTask.completedAt ? '🎉 Completed!' : '🔥 Ongoing';
+  const status = !!userTask.completedAt
+    ? '🎉 Completed!'
+    : isAfter(new Date(userTask.scheduledFor), new Date())
+    ? '💪 Upcoming'
+    : '🔥 Ongoing';
 
   const handleDoneToggle = () => {
     if (!userTask.completedAt) {

--- a/frontend/src/pages/challenge/ChallengeDetailsPage.tsx
+++ b/frontend/src/pages/challenge/ChallengeDetailsPage.tsx
@@ -50,8 +50,8 @@ const useStyles = makeStyles(() => ({
   peekDrawer: {
     position: 'relative',
     backgroundColor: '#fff',
-    borderTopLeftRadius: 8,
-    borderTopRightRadius: 8,
+    borderTopLeftRadius: 30,
+    borderTopRightRadius: 30,
     visibility: 'visible',
     right: 0,
     left: 0,
@@ -77,6 +77,12 @@ const useStyles = makeStyles(() => ({
   tabPanel: {
     overflowY: 'scroll',
     height: '75vh',
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
+  topPadding: {
+    paddingTop: '1em',
   },
 }));
 
@@ -186,13 +192,18 @@ const ChallengeDetailsPage: React.FC = () => {
         <Typography variant="h1" className={classes.white}>
           {challenge.name}
         </Typography>
-        <Typography className={classes.white}>
-          {challenge.duration} days {challenge.createdBy}
+        <Typography className={`${classes.white} ${classes.bold}`}>
+          {challenge.duration} days · Created by {challenge.createdBy}
         </Typography>
-        <Typography className={classes.white}>
+        <Typography className={`${classes.white} ${classes.topPadding}`}>
           {challenge.description}
         </Typography>
-        <Typography className={classes.white}>Recommended schedule</Typography>
+        <Typography
+          variant="h6"
+          className={`${classes.white} ${classes.topPadding} ${classes.bold}`}
+        >
+          Recommended schedule
+        </Typography>
         <Typography className={classes.white}>{challenge.schedule}</Typography>
 
         {/* User has not enrolled in the challenge */}

--- a/frontend/src/pages/challenge/ChallengeDetailsPage.tsx
+++ b/frontend/src/pages/challenge/ChallengeDetailsPage.tsx
@@ -50,8 +50,8 @@ const useStyles = makeStyles(() => ({
   peekDrawer: {
     position: 'relative',
     backgroundColor: '#fff',
-    borderTopLeftRadius: 30,
-    borderTopRightRadius: 30,
+    borderTopLeftRadius: 35,
+    borderTopRightRadius: 35,
     visibility: 'visible',
     right: 0,
     left: 0,
@@ -248,18 +248,22 @@ const ChallengeDetailsPage: React.FC = () => {
           <Box className={classes.peekDrawer} sx={{ top: -peekDrawerHeight }}>
             <Box className={classes.puller} />
             <TabContext value={currentTabItem}>
-              <TabList
-                onChange={(_: React.SyntheticEvent, newValue: TabItem) => {
-                  setCurrentTabItem(newValue);
-                }}
-              >
-                {Object.values(TabItem).map((tabItem) => {
-                  if (privateTabs.includes(tabItem) && !userChallenge) {
-                    return null;
-                  }
-                  return <Tab key={tabItem} label={tabItem} value={tabItem} />;
-                })}
-              </TabList>
+              <Box sx={{ padding: '0.5em 0 0 2em' }}>
+                <TabList
+                  onChange={(_: React.SyntheticEvent, newValue: TabItem) => {
+                    setCurrentTabItem(newValue);
+                  }}
+                >
+                  {Object.values(TabItem).map((tabItem) => {
+                    if (privateTabs.includes(tabItem) && !userChallenge) {
+                      return null;
+                    }
+                    return (
+                      <Tab key={tabItem} label={tabItem} value={tabItem} />
+                    );
+                  })}
+                </TabList>
+              </Box>
 
               {Object.values(TabItem).map((tabItem) => (
                 <TabPanel

--- a/frontend/src/pages/challenge/ChallengeDetailsPage.tsx
+++ b/frontend/src/pages/challenge/ChallengeDetailsPage.tsx
@@ -64,7 +64,7 @@ const useStyles = makeStyles(() => ({
     borderRadius: 3,
     position: 'absolute',
     left: 'calc(50% - 45px)',
-    top: '-14px',
+    top: '-10px',
   },
   white: {
     color: 'white',
@@ -72,7 +72,10 @@ const useStyles = makeStyles(() => ({
   joinButton: {
     marginTop: '28px',
     borderRadius: '20px',
-    height: '60px',
+    height: '50px',
+    maxWidth: '300px',
+    left: '50%',
+    transform: 'translateX(-50%)',
   },
   tabPanel: {
     overflowY: 'scroll',
@@ -82,7 +85,10 @@ const useStyles = makeStyles(() => ({
     fontWeight: 'bold',
   },
   topPadding: {
-    paddingTop: '1em',
+    paddingTop: '0.7em',
+  },
+  removeMargin: {
+    marginBottom: '-0.5em',
   },
 }));
 
@@ -127,7 +133,7 @@ const ChallengeDetailsPage: React.FC = () => {
     TabItem.Milestones
   );
 
-  const peekDrawerHeight = 200;
+  const peekDrawerHeight = 20;
 
   const Bar = () => (
     <AppBar position="static">
@@ -204,7 +210,28 @@ const ChallengeDetailsPage: React.FC = () => {
         >
           Recommended schedule
         </Typography>
-        <Typography className={classes.white}>{challenge.schedule}</Typography>
+        <Typography className={`${classes.white} ${classes.removeMargin}`}>
+          {challenge.schedule}
+        </Typography>
+        <Button
+          variant="outlined"
+          fullWidth
+          disableElevation
+          className={classes.joinButton}
+          sx={{
+            marginBottom: '-1.5em',
+            borderRadius: '1.5em',
+            backgroundColor: 'transparent',
+            color: 'white',
+            border: '1px white solid',
+            display: 'block',
+          }}
+          onClick={() => {
+            setIsDrawerOpen(true);
+          }}
+        >
+          <Typography variant="body1">View details</Typography>
+        </Button>
 
         {/* User has not enrolled in the challenge */}
         {/* TODO: ensure that user has < 3 challenges before allowing user to enroll */}
@@ -213,6 +240,7 @@ const ChallengeDetailsPage: React.FC = () => {
             <Button
               variant="contained"
               fullWidth
+              disableElevation
               className={classes.joinButton}
               onClick={() => setIsScheduleModalOpen(true)}
             >

--- a/frontend/src/pages/explore/ExplorePage.tsx
+++ b/frontend/src/pages/explore/ExplorePage.tsx
@@ -86,7 +86,7 @@ const ExplorePage: React.FC = () => {
 
   return (
     <Box sx={{ padding: '2em 1.5em 0 1.5em' }}>
-      <Typography variant="h2">Find your next challenge</Typography>
+      <Typography variant="h1">Find your next challenge</Typography>
       <Searchbar
         placeholder="Search by challenge name..."
         onChange={eventhandler}

--- a/frontend/src/routing/routes.ts
+++ b/frontend/src/routing/routes.ts
@@ -36,6 +36,14 @@ export const notAuthenticatedRoutes: RouteEntry[] = [
 // Public routes that are accessible regardless of authentication status
 export const publicRoutes: RouteEntry[] = [];
 
+// Route that appear on the navbar
+export const mainRoutes: RouteEntry[] = [
+  { path: PROFILE_ROUTE, component: ProfilePage, exact: true },
+  { path: HOME_ROUTE, component: HomePage, exact: true },
+  { path: FEED_ROUTE, component: FeedPage, exact: true },
+  { path: EXPLORE_ROUTE, component: ExplorePage },
+];
+
 export const privateRoutes: RouteEntry[] = [
   { path: EDIT_PROFILE_ROUTE, component: EditProfilePage, exact: true },
   { path: PROFILE_ROUTE, component: ProfilePage, exact: true },

--- a/frontend/src/utils/theme.ts
+++ b/frontend/src/utils/theme.ts
@@ -17,7 +17,7 @@ const theme = createTheme({
     fontFamily: `"CircularStd", "Helvetica", "Arial", sans-serif, "Frock"`,
     h1: {
       fontFamily: 'Frock',
-      fontSize: 50,
+      fontSize: '40px',
     },
     h2: {
       fontFamily: 'Frock',


### PR DESCRIPTION
 - Add upcoming status label for tasks after today in task card
 - If task is still upcoming, remove toggle to prevent confusion/ user error
 - Style challenge description page a bit
 - Make navbar appear only in main pages (not sure if my implementation is too clunky?) Also solves the bug where you can click through the drawer into the navbar on the challenge pages
 - Add temporary view details button in challenge page so the drawer can be opened on desktop (but now there's no space so I had to make the drawer peek out minimally :'( )... Is the drawer really unopenable on click? 