### PR TITLE
Update date carousel 'from now' display

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,10 +22,10 @@ import { RouteEntry } from './types/routes';
 import Notifier from 'components/notifier';
 import FeedbackOverlay from './components/common/FeedbackOverlay';
 import { useCache } from 'components/common/cacheProvider';
+import GoogleAnalytics from './GoogleAnalytics';
 
 import './App.scss';
 import 'swiper/swiper-bundle.css';
-import GoogleAnalytics from './GoogleAnalytics';
 
 function App(): JSX.Element {
   const dispatch = useDispatch();

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -28,12 +28,28 @@ export function getISOStringAtStartOfDay(date: Date): string {
 }
 
 export function getDateFromNowString(date: Date): string {
-  return dayjs(date).calendar(null, {
-    lastWeek: '[Last] dddd',
+  const format = {
     lastDay: '[Yesterday]',
     sameDay: '[Today]',
     nextDay: '[Tomorrow]',
-    nextWeek: 'dddd',
     sameElse: () => dayjs(date).fromNow(),
-  });
+  };
+  const referenceStartOfDay = dayjs().startOf('d');
+  const diff = referenceStartOfDay.diff(date, 'd', true);
+  const sameElse = 'sameElse';
+  const retVal =
+    diff < -2
+      ? sameElse
+      : diff < -1
+      ? 'nextDay'
+      : diff < 0
+      ? 'sameDay'
+      : diff < 1
+      ? 'lastDay'
+      : sameElse;
+  const currentFormat = format[retVal];
+  if (typeof currentFormat === 'function') {
+    return currentFormat();
+  }
+  return dayjs(date).format(currentFormat);
 }


### PR DESCRIPTION
@jialin7878's user feedbacked that the 'from now' display for dates within a week isn't very helpful (i.e. `Tue\nTuesday`). Make dates beyond 1 day from the current date display using `dayjs(date).fromNow()` instead.