### PR TITLE
Dismiss snackbars on click

### DIFF
--- a/frontend/src/components/notifier/Notifier.tsx
+++ b/frontend/src/components/notifier/Notifier.tsx
@@ -7,7 +7,7 @@ import { SnackbarKey } from 'store/snackbars/types';
 
 const Notifier: React.FC = () => {
   const dispatch = useDispatch();
-  const { enqueueSnackbar } = useSnackbar();
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const snackbars = useSelector(getSnackbars);
 
   const [displayedSnackbarKeys, setDisplayedSnackbarKeys] = useState<
@@ -21,8 +21,9 @@ const Notifier: React.FC = () => {
         return;
       }
 
-      enqueueSnackbar(snackbar.message, {
+      const key = enqueueSnackbar(snackbar.message, {
         variant: snackbar.variant,
+        onClick: () => closeSnackbar(key),
       });
 
       setDisplayedSnackbarKeys([...displayedSnackbarKeys, snackbar.key]);


### PR DESCRIPTION
This is useful on small devices where the snackbar might be blocking some essential part of the UI.