### PR TITLE
Add caching of assets

### DIFF
--- a/deployment/nginx/sites-enabled/odyssey-app.com
+++ b/deployment/nginx/sites-enabled/odyssey-app.com
@@ -61,6 +61,34 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
+
+  # This block will catch static file requests, such as images
+  location ~* \.(?:jpg|jpeg|gif|png|ico|xml|webp)$ {
+    access_log        off;
+    log_not_found     off;
+
+    expires           30d;
+    add_header        Pragma public;
+    add_header        Cache-Control "public";
+  }
+
+  # This block will catch static file requests of fonts
+  # and allows fonts to be requested via CORS
+  location ~* \.(?:eot|woff|woff2|ttf|svg|otf) {
+    access_log        off;
+    log_not_found     off;
+
+    expires           30d;
+    add_header        Cache-Control "public";
+    add_header        Access-Control-Allow-Origin *;
+
+    types             {font/opentype otf;}
+    types             {application/vnd.ms-fontobject eot;}
+    types             {font/truetype ttf;}
+    types             {application/font-woff woff;}
+    types             {font/x-woff woff2;}
+    types             {image/svg+xml svg svgz;}
+  }
 }
 
 # Catch-all for unrecognised requests


### PR DESCRIPTION
Assets aren't being cached on production environment which results in the assets needing to be loaded every time

To test:
- head to Explore tab
- head to some other tab
- head to Explore tab again
- On the production environment, visually observe that the assets needs to be loaded again / look at network tab of browser console. Contrast this with the local environment (using the same steps)

Same assets being fetched multiple times on production environment:
![image](https://user-images.githubusercontent.com/24363622/139517310-e8408af7-733d-48fe-b013-c4138f5850e4.png)

vs on local environment with caching enabled:
![image](https://user-images.githubusercontent.com/24363622/139517335-afae7249-3652-4299-bf94-2d5c3b92c028.png)


I'm not exactly sure if this fixes it haha (how can I go about testing this?)
- Solution adapted from https://gist.github.com/philipstanislaus/654adafad91efb6de230845b5bdeae61