### PR TITLE
Cache image assets

### DIFF
--- a/deployment/nginx/sites-enabled/odyssey-app.com
+++ b/deployment/nginx/sites-enabled/odyssey-app.com
@@ -61,6 +61,16 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
+
+  # This block will catch static file requests, such as images
+  location ~* \.(?:jpg|jpeg|gif|png|ico|xml|webp)$ {
+    access_log        off;
+    log_not_found     off;
+
+    expires           30d;
+    add_header        Pragma public;
+    add_header        Cache-Control "public";
+  }
 }
 
 # Catch-all for unrecognised requests

--- a/frontend/src/pages/category/CategoryPage.tsx
+++ b/frontend/src/pages/category/CategoryPage.tsx
@@ -76,7 +76,7 @@ const StyledTab = styled((props: StyledTabProps) => (
   },
 }));
 
-const ExplorePage: React.FC = () => {
+const CategoryPage: React.FC = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const { categoryId } = useParams<{ categoryId: string }>();
@@ -189,4 +189,4 @@ const ExplorePage: React.FC = () => {
   );
 };
 
-export default ExplorePage;
+export default CategoryPage;


### PR DESCRIPTION
Couldn't get caching of fonts to work, but I think this isn't that much of an issue 

Other changes to server config file:

`.../sites-enabled/odyssey-app.com`
- Commented out the line below
![image](https://user-images.githubusercontent.com/24363622/139537616-718225ed-9490-492d-aac3-8bf54258d39b.png)



Also in this PR:
- Fix naming of CategoryPage component

Supersedes https://github.com/0dy553y/odyssey/pull/131