### PR TITLE
Add word break and remove links to profiles from avatar in profile / edit profile page

### DIFF
--- a/backend/lib/tasks/20211031173530_add_couch_and_meditation.rake
+++ b/backend/lib/tasks/20211031173530_add_couch_and_meditation.rake
@@ -25,68 +25,55 @@ task add_couch_and_meditation: :environment do
                                        color: 0)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 1',
-                description: 'Begin with a brisk 5 min walk, then alternate 1 min of running and
-            1.5 min of walking for a total of 20 min',
+                description: 'Begin with a brisk 5 min walk, then alternate 1 min of running and 1.5 min of walking for a total of 20 min',
                 index: 0)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 1',
-                description: 'Begin with a brisk 5 min walk, then alternate 1 min of running and
-            1.5 min of walking for a total of 20 min',
+                description: 'Begin with a brisk 5 min walk, then alternate 1 min of running and 1.5 min of walking for a total of 20 min',
                 index: 1)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 1',
-                description: 'Begin with a brisk 5 min walk, then alternate 1 min of running and
-            1.5 min of walking for a total of 20 min',
+                description: 'Begin with a brisk 5 min walk, then alternate 1 min of running and 1.5 min of walking for a total of 20 min',
                 index: 2)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 2',
-                description: 'Begin with a brisk 5 min walk, then alternate 1.5 min of running and
-            2 min of walking for a total of 20 min',
+                description: 'Begin with a brisk 5 min walk, then alternate 1.5 min of running and 2 min of walking for a total of 20 min',
                 index: 3)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 2',
-                description: 'Begin with a brisk 5 min walk, then alternate 1.5 min of running and
-            2 min of walking for a total of 20 min',
+                description: 'Begin with a brisk 5 min walk, then alternate 1.5 min of running and 2 min of walking for a total of 20 min',
                 index: 4)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 2',
-                description: 'Begin with a brisk 5 min walk, then alternate 1.5 min of running and
-            2 min of walking for a total of 20 min',
+                description: 'Begin with a brisk 5 min walk, then alternate 1.5 min of running and 2 min of walking for a total of 20 min',
                 index: 5)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 3',
-                description: 'Begin with a brisk 5 min walk, then 2 repitions of 1.5 min of running,
-            1.5 min of walking, 3 min of running and 3 min of walking',
+                description: 'Begin with a brisk 5 min walk, then 2 repetitions of 1.5 min of running, 1.5 min of walking, 3 min of running and 3 min of walking',
                 index: 6)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 3',
-                description: 'Begin with a brisk 5 min walk, then 2 repitions of 1.5 min of running,
-            1.5 min of walking, 3 min of running and 3 min of walking',
+                description: 'Begin with a brisk 5 min walk, then 2 repetitions of 1.5 min of running, 1.5 min of walking, 3 min of running and 3 min of walking',
                 index: 7)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 3',
-                description: 'Begin with a brisk 5 min walk, then 2 repitions of 1.5 min of running,
-            1.5 min of walking, 3 min of running and 3 min of walking',
+                description: 'Begin with a brisk 5 min walk, then 2 repetitions of 1.5 min of running, 1.5 min of walking, 3 min of running and 3 min of walking',
                 index: 8)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 4',
-                description: 'Begin with a brisk 5 min walk, then 3 min of running, 1.5 min of walking,
-            5 min of running, 2.5 min of walking, 3 min of running, 1.5 min of walking, 5 min of running',
+                description: 'Begin with a brisk 5 min walk, then 3 min of running, 1.5 min of walking, 5 min of running, 2.5 min of walking, 3 min of running, 1.5 min of walking, 5 min of running',
                 index: 9)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 4',
-                description: 'Begin with a brisk 5 min walk, then 3 min of running, 1.5 min of walking,
-            5 min of running, 2.5 min of walking, 3 min of running, 1.5 min of walking, 5 min of running',
+                description: 'Begin with a brisk 5 min walk, then 3 min of running, 1.5 min of walking, 5 min of running, 2.5 min of walking, 3 min of running, 1.5 min of walking, 5 min of running',
                 index: 10)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 4',
-                description: 'Begin with a brisk 5 min walk, then 3 min of running, 1.5 min of walking,
-            5 min of running, 2.5 min of walking, 3 min of running, 1.5 min of walking, 5 min of running',
+                description: 'Begin with a brisk 5 min walk, then 3 min of running, 1.5 min of walking, 5 min of running, 2.5 min of walking, 3 min of running, 1.5 min of walking, 5 min of running',
                 index: 11)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 5',
-                description: 'Begin with a brisk 5 min walk, then 5 min of running, 3 min of walking,
-            5 min of running, 3 min of walking, and 5 min of running',
+                description: 'Begin with a brisk 5 min walk, then 5 min of running, 3 min of walking, 5 min of running, 3 min of walking, and 5 min of running',
                 index: 12)
     Task.create(challenge_id: challenge_couch.id,
                 name: 'Week 5',
@@ -163,70 +150,51 @@ task add_couch_and_meditation: :environment do
                                             color: 0)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 1 - Focus on your breath',
-                description: 'Start with 5 min meditation session and when doing so, focus on your breath.
-            Breath is the closest link we have with the present moment hence focusing on breathing will allow you to
-            bring your mind and body together.',
+                description: 'Start with 5 min meditation session and when doing so, focus on your breath. Breath is the closest link we have with the present moment hence focusing on breathing will allow you to bring your mind and body together.',
                 index: 0)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 2 - 5 min of meditation',
-                description: 'Continue with 5 min of meditation of your choice. You could simply repeat the same meditation,
-            if you like it, or experiment and choose a new one for each day.',
+                description: 'Continue with 5 min of meditation of your choice. You could simply repeat the same meditation, if you like it, or experiment and choose a new one for each day.',
                 index: 1)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 3 - 5 min of meditation',
-                description: 'Continue with 5 min of meditation of your choice. You could simply repeat the same meditation,
-            if you like it, or experiment and choose a new one for each day.',
+                description: 'Continue with 5 min of meditation of your choice. You could simply repeat the same meditation, if you like it, or experiment and choose a new one for each day.',
                 index: 2)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 4 - Think of someone you love',
-                description: 'Do your 5 min of meditation but don’t stand up yet. Once you have finished your meditation,
-            think of someone you love: your partner, family member, close friend or maybe even your pet.
-            Imagine that person smiling and think how happy you are to have him/her in your life.
-            Keep this positive energy with you for the rest of your day!',
+                description: 'Do your 5 min of meditation but don’t stand up yet. Once you have finished your meditation, think of someone you love: your partner, family member, close friend or maybe even your pet. Imagine that person smiling and think how happy you are to have him/her in your life. Keep this positive energy with you for the rest of your day!',
                 index: 3)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 5 - 5 min of meditation',
-                description: 'Do 5 min of meditation of your choice. Whenever possible, try to stick to the same meditation
-            time – be it morning, lunch break or evening. Having a set time will help you to establish your own
-            meditation routine easier and help you form a positive habit.',
+                description: 'Do 5 min of meditation of your choice. Whenever possible, try to stick to the same meditation time – be it morning, lunch break or evening. Having a set time will help you to establish your own meditation routine easier and help you form a positive habit.',
                 index: 4)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 6 - 5 min of meditation',
-                description: 'Do 5 min of meditation of your choice. Whenever possible, try to stick to the same meditation
-            time – be it morning, lunch break or evening.',
+                description: 'Do 5 min of meditation of your choice. Whenever possible, try to stick to the same meditation time – be it morning, lunch break or evening.',
                 index: 5)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 7 - List 3 things you are grateful for',
-                description: 'Once you have done your 5 min of meditation, sit down for a bit longer, take a piece of paper
-             and list 3 things you are grateful about.',
+                description: 'Once you have done your 5 min of meditation, sit down for a bit longer, take a piece of paper and list 3 things you are grateful about.',
                 index: 6)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 8 - 5 min of meditation',
-                description: 'To start your second week of daily meditation, prolong your session to 10 min. If 10 min
-            is too much for you, keep it to 5 min and increase the time once you feel ready for it.  At this point,
-            you are developing a habit of meditating hence consistency is more important than intensity.',
+                description: 'To start your second week of daily meditation, prolong your session to 10 min. If 10 min is too much for you, keep it to 5 min and increase the time once you feel ready for it.  At this point, you are developing a habit of meditating hence consistency is more important than intensity.',
                 index: 7)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 9 - Say 5 positive things about yourself',
-                description: 'Meditate for 10 min. At the end of today’s meditation, think of 5 positive things about
-            yourself and say them out loud. Not only will this boost your confidence and self-love, but will also
-            make you less stressed and healthier.',
+                description: 'Meditate for 10 min. At the end of today’s meditation, think of 5 positive things about yourself and say them out loud. Not only will this boost your confidence and self-love, but will also make you less stressed and healthier.',
                 index: 8)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 10 - List 3 things you are grateful for',
-                description: 'Once you have done your 10 min of meditation, sit down for a bit longer, take a piece of paper
-            and list 3 things you are grateful about.',
+                description: 'Once you have done your 10 min of meditation, sit down for a bit longer, take a piece of paper and list 3 things you are grateful about.',
                 index: 9)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 11 - 10 min of meditation',
-                description: 'Do 10 min of meditation. Identify the time that has worked best so far for your
-            meditation practice and stick to it as much you can to keep going forward. Now, think of a cue/action that
-            triggers your meditation. This will be the action that will tell your brain “it’s time to meditate”.',
+                description: 'Do 10 min of meditation. Identify the time that has worked best so far for your meditation practice and stick to it as much you can to keep going forward. Now, think of a cue/action that triggers your meditation. This will be the action that will tell your brain “it’s time to meditate”.',
                 index: 10)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 12 - List 3 positive things that happened today',
-                description: 'Do 10 min of meditation. Before you go to sleep, think of your day and list 3 positive
-             things that have happened to you today.',
+                description: 'Do 10 min of meditation. Before you go to sleep, think of your day and list 3 positive things that have happened to you today.',
                 index: 11)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 13 - 10 min of meditation',
@@ -234,9 +202,7 @@ task add_couch_and_meditation: :environment do
                 index: 12)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 14 - Visualize a place you love',
-                description: 'Meditate for 10 min. At the end, close your eyes and think of a place you love. A place
-             where you feel safe and happy. Visualize as if you were there right now and think of all the details:
-              furniture, colors, sounds, texture.',
+                description: 'Meditate for 10 min. At the end, close your eyes and think of a place you love. A place where you feel safe and happy. Visualize as if you were there right now and think of all the details: furniture, colors, sounds, texture.',
                 index: 13)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 15 - List 3 things you are grateful for',
@@ -244,9 +210,7 @@ task add_couch_and_meditation: :environment do
                 index: 14)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 16 - Take a few deep breaths outside',
-                description: 'Meditate for 10 min. Today make sure to go outside, stand still and take 3-5
-             deep long breaths: inhale deeply through. Taking a few deep breaths will help you to connect with
-              yourself and make you be aware of the current moment.',
+                description: 'Meditate for 10 min. Today make sure to go outside, stand still and take 3-5 deep long breaths: inhale deeply through. Taking a few deep breaths will help you to connect with yourself and make you be aware of the current moment.',
                 index: 15)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 17 - 10 min of meditation',
@@ -254,24 +218,19 @@ task add_couch_and_meditation: :environment do
                 index: 16)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 18 - Say 3 compliments to yourself',
-                description: 'Meditate for 10 min. Think of all the great things about you and say out loud
-            3 compliments to yourself. You can do it after your meditation practice, once you wake up or even in
-               the middle of the day before an important meeting.',
+                description: 'Meditate for 10 min. Think of all the great things about you and say out loud 3 compliments to yourself. You can do it after your meditation practice, once you wake up or even in the middle of the day before an important meeting.',
                 index: 17)
     Task.create(challenge_id: challenge_meditation.id,
-                name: 'Dat 19 - List 3 positive things that happened today',
+                name: 'Day 19 - List 3 positive things that happened today',
                 description: 'Meditate for 10 min. List 3 great things that happened to you today before you fall asleep.',
                 index: 18)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 20 - List 5 people you love',
-                description: 'Meditate for 10 min. List 5 people you love and when doing so, think of each of
-             the people for at least a few seconds. Remember them any time you feel down and be grateful for
-             having them in your life.',
+                description: 'Meditate for 10 min. List 5 people you love and when doing so, think of each of the people for at least a few seconds. Remember them any time you feel down and be grateful for having them in your life.',
                 index: 19)
     Task.create(challenge_id: challenge_meditation.id,
                 name: 'Day 21 - Final 15 min meditation',
-                description: 'Congratulations on coming this far! To celebrate your achievements, challenge yourself
-             a bit more and prolong your meditation to 15 minutes today.',
+                description: 'Congratulations on coming this far! To celebrate your achievements, challenge yourself a bit more and prolong your meditation to 15 minutes today.',
                 index: 20)
   end
 end

--- a/backend/lib/tasks/20211031173530_add_couch_and_meditation.rake
+++ b/backend/lib/tasks/20211031173530_add_couch_and_meditation.rake
@@ -221,7 +221,7 @@ task add_couch_and_meditation: :environment do
                 description: 'Meditate for 10 min. Think of all the great things about you and say out loud 3 compliments to yourself. You can do it after your meditation practice, once you wake up or even in the middle of the day before an important meeting.',
                 index: 17)
     Task.create(challenge_id: challenge_meditation.id,
-                name: 'Day 19 - List 3 positive things that happened today',
+                name: 'Day 19 - List 3 positive things',
                 description: 'Meditate for 10 min. List 3 great things that happened to you today before you fall asleep.',
                 index: 18)
     Task.create(challenge_id: challenge_meditation.id,

--- a/frontend/src/components/challenge/ChallengeMilestones.tsx
+++ b/frontend/src/components/challenge/ChallengeMilestones.tsx
@@ -47,6 +47,10 @@ const useStyles = makeStyles(() => ({
   displayLineBreak: {
     whiteSpace: 'pre-line',
   },
+  wrapText: {
+    wordBreak: 'break-word',
+    hyphens: 'auto',
+  },
 }));
 
 const ChallengeMilestones: React.FC<ChallengeMilestonesProps> = (props) => {
@@ -138,7 +142,9 @@ const ChallengeMilestones: React.FC<ChallengeMilestonesProps> = (props) => {
             </TimelineSeparator>
             <TimelineContent>
               <Typography className={classes.title}>{t.name}</Typography>
-              <Typography className={classes.displayLineBreak}>
+              <Typography
+                className={`${classes.displayLineBreak} ${classes.wrapText}`}
+              >
                 {t.description}
               </Typography>
             </TimelineContent>

--- a/frontend/src/components/common/userAvatar/UserAvatar.tsx
+++ b/frontend/src/components/common/userAvatar/UserAvatar.tsx
@@ -12,6 +12,7 @@ interface UserAvatarProps {
   username: string;
   displayName?: string;
   className?: string;
+  shouldLinkToProfile?: boolean;
 }
 
 const UserAvatar: React.FC<UserAvatarProps> = ({
@@ -19,6 +20,7 @@ const UserAvatar: React.FC<UserAvatarProps> = ({
   username,
   displayName,
   className,
+  shouldLinkToProfile = true,
 }) => {
   const history = useHistory();
   const user = useSelector(getUser);
@@ -30,6 +32,10 @@ const UserAvatar: React.FC<UserAvatarProps> = ({
       src={src}
       {...stringAvatar(displayName ?? username)}
       onClick={() => {
+        if (!shouldLinkToProfile) {
+          return;
+        }
+
         if (user?.username === username) {
           history.push(`${PROFILE_ROUTE}`);
           return;

--- a/frontend/src/components/profile/ProfileHeader.tsx
+++ b/frontend/src/components/profile/ProfileHeader.tsx
@@ -27,6 +27,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = (props) => {
           src={user.avatar}
           username={user.username}
           displayName={user.displayName}
+          shouldLinkToProfile={false}
         />
       </IconButton>
 

--- a/frontend/src/pages/editProfile/EditProfilePage.tsx
+++ b/frontend/src/pages/editProfile/EditProfilePage.tsx
@@ -109,6 +109,7 @@ const EditProfilePage: React.FC = () => {
                     src={avatarBase64DataUrl || user.avatar}
                     username={user.username}
                     displayName={user.displayName}
+                    shouldLinkToProfile={false}
                   />
                 </Badge>
               </label>

--- a/frontend/src/pages/profile/ProfilePage.tsx
+++ b/frontend/src/pages/profile/ProfilePage.tsx
@@ -197,31 +197,39 @@ const ProfilePage: React.FC = () => {
                 </div>
               )}
               <Box sx={{ flexGrow: 1 }} />
-              <IconButton edge="end" color="primary" onClick={handleMenuClick}>
-                <MoreVertIcon />
-              </IconButton>
-              <Menu
-                anchorEl={menuAnchorEl}
-                open={isMenuOpen}
-                onClose={handleMenuClose}
-              >
-                <MenuItem
-                  onClick={() => {
-                    handleMenuClose();
-                    history.push(EDIT_PROFILE_ROUTE);
-                  }}
-                >
-                  Edit Profile
-                </MenuItem>
-                <MenuItem
-                  onClick={() => {
-                    handleMenuClose();
-                    dispatch(logout(history));
-                  }}
-                >
-                  Logout
-                </MenuItem>
-              </Menu>
+              {isOwnProfilePage && (
+                <>
+                  <IconButton
+                    edge="end"
+                    color="primary"
+                    onClick={handleMenuClick}
+                  >
+                    <MoreVertIcon />
+                  </IconButton>
+                  <Menu
+                    anchorEl={menuAnchorEl}
+                    open={isMenuOpen}
+                    onClose={handleMenuClose}
+                  >
+                    <MenuItem
+                      onClick={() => {
+                        handleMenuClose();
+                        history.push(EDIT_PROFILE_ROUTE);
+                      }}
+                    >
+                      Edit Profile
+                    </MenuItem>
+                    <MenuItem
+                      onClick={() => {
+                        handleMenuClose();
+                        dispatch(logout(history));
+                      }}
+                    >
+                      Logout
+                    </MenuItem>
+                  </Menu>
+                </>
+              )}
             </Toolbar>
           </AppBar>
 


### PR DESCRIPTION
Resolves https://github.com/0dy553y/odyssey/issues/172, https://github.com/0dy553y/odyssey/issues/194 and https://github.com/0dy553y/odyssey/issues/185

Changes:
- added word wrap to task description
- remove link to user profiles by clicking on avatar in profile page / edit profile page
- Hide menu item (e.g. log out, edit profile) if viewing other people's profile
- fixed some seeds:
  - removed line breaks, fixed some typos ('repetition' being mispelled)
  - Added missing task due to task name being too long and error being silently dismissed during seed process  (`create` was used instead of `create!`)

Ran the following commands on prod
```
c = Challenge.find_by(name: 'Couch to 5k')
c.tasks.each do |t|
  if t.name == 'Week 3'
    t.description = 'Begin with a brisk 5 min walk, then 2 repetitions of 1.5 min of running, 1.5 min of walking, 3 min of running and 3 min of walking'
  end

  t.description.squish!
  t.save!
end

c = Challenge.find_by(name: 'Meditation')
c.tasks.each do |t|

  t.description.squish!
  t.save!
end


Task.create!(challenge_id: c.id,
            name: 'Day 19 - List 3 positive things',
            description: 'Meditate for 10 min. List 3 great things that happened to you today before you fall asleep.',
            index: 18)
```

