### PR TITLE
Make home page greeting more space-efficient

### DIFF
--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_04_064011) do
+ActiveRecord::Schema.define(version: 2021_11_04_104206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -195,6 +195,7 @@ ActiveRecord::Schema.define(version: 2021_11_04_064011) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "is_system_account", default: false
+    t.integer "character", default: 0
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -35,14 +35,19 @@ const useStyles = makeStyles(() => ({
     marginLeft: 30,
     marginRight: 30,
     width: 'auto',
+    display: 'flex',
+    flexDirection: 'row',
   },
   tasksContainer: {
     height: '100%',
     marginTop: 10,
     marginBottom: 15,
   },
+  greetingsContainer: {
+    flexGrow: 1,
+  },
   controlsContainer: {
-    textAlign: 'right',
+    whiteSpace: 'nowrap',
   },
 }));
 
@@ -119,21 +124,14 @@ const HomePage: React.FC = () => {
     <div className={classes.baseContainer}>
       <div className={classes.headerContainer}>
         <Grid container direction="column" spacing={2}>
-          <Grid
-            item
-            container
-            direction="row"
-            className={classes.headerNonCarouselItem}
-          >
-            <Grid item container xs={6} sm={9}>
-              <Grid item>
-                <Typography variant="h4">Hello,</Typography>
-                <Typography variant="h4">
-                  {user.displayName ?? user.username}
-                </Typography>
-              </Grid>
-            </Grid>
-            <Grid item xs={6} sm={3} className={classes.controlsContainer}>
+          <Grid item direction="row" className={classes.headerNonCarouselItem}>
+            <div className={classes.greetingsContainer}>
+              <Typography variant="h4">Hello,</Typography>
+              <Typography variant="h4">
+                {user.displayName ?? user.username}
+              </Typography>
+            </div>
+            <div className={classes.controlsContainer}>
               <IconButton
                 size="large"
                 onClick={() => history.push(NOTIFICATIONS_ROUTE)}
@@ -146,7 +144,7 @@ const HomePage: React.FC = () => {
               >
                 <TodayIcon fontSize="inherit" />
               </IconButton>
-            </Grid>
+            </div>
           </Grid>
           <Grid item className={classes.headerCarouselItem}>
             <DateCarousel date={date} setDate={setDate} />


### PR DESCRIPTION
Also add the updated `schema.rb` from running the latest migrations.

Before:

![image](https://user-images.githubusercontent.com/5585517/140547140-36c62d36-4607-48f5-8f61-0b2ebdbb6d15.png)

After:

![image](https://user-images.githubusercontent.com/5585517/140547249-fccb05b8-2c91-4abb-a428-58bd6e7fe841.png)

Resolves #202.