### PR TITLE
Prefetch daily user tasks

### DIFF
--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState, useReducer } from 'react';
-import { loadUserTasksForDay } from '../../store/usertasks/operations';
+import {
+  loadUserTasksForDay,
+  loadUserTasksForDays,
+} from '../../store/usertasks/operations';
 import { useDispatch, useSelector } from 'react-redux';
 import UserTaskCarousel from '../../components/home/UserTaskCarousel';
 import MapDialog from '../../components/map/MapDialog';
@@ -104,7 +107,9 @@ const HomePage: React.FC = () => {
   };
 
   useEffect(() => {
+    // Note: Not batched on purpose so that today's tasks load faster.
     dispatch(loadUserTasksForDay(date));
+    dispatch(loadUserTasksForDays(date, 15));
   }, [date]);
 
   const userTaskList = Array.from(

--- a/frontend/src/store/usertasks/operations.ts
+++ b/frontend/src/store/usertasks/operations.ts
@@ -15,12 +15,33 @@ import {
   saveUserTaskForDay,
   saveUserTaskListForDay,
 } from './actions';
+import { getNeighbouringDates } from '../../utils/date';
 
 export function loadUserTasksForDay(date: Date): OperationResult {
   return async (dispatch: ThunkDispatch<RootState, undefined, AnyAction>) => {
     const response = await api.userTasks.getUserTaskListForDay(date);
     const userTasks: UserTaskListData[] = response.payload.data;
     dispatch(saveUserTaskListForDay(date, userTasks));
+  };
+}
+
+export function loadUserTasksForDays(
+  date: Date,
+  range: number
+): OperationResult {
+  return async (dispatch: ThunkDispatch<RootState, undefined, AnyAction>) => {
+    const dates = getNeighbouringDates(date, range);
+    const apiCalls: Promise<void>[] = [];
+    dates.forEach((date: Date) => {
+      apiCalls.push(
+        new Promise(async () => {
+          const response = await api.userTasks.getUserTaskListForDay(date);
+          const userTasks: UserTaskListData[] = response.payload.data;
+          dispatch(saveUserTaskListForDay(date, userTasks));
+        })
+      );
+    });
+    await Promise.all(apiCalls);
   };
 }
 


### PR DESCRIPTION
This is to prevent the flickering of user tasks when loading a different date.

Fixes #192.