### PR TITLE
Prevent scrolling with mouse wheel for user task carousel

### DIFF
--- a/frontend/src/components/home/UserTaskCarousel.tsx
+++ b/frontend/src/components/home/UserTaskCarousel.tsx
@@ -98,7 +98,6 @@ const UserTaskCarousel: React.FC<Props> = ({
       spaceBetween={20}
       slideToClickedSlide
       keyboard={{ enabled: true }}
-      mousewheel={true}
       className="task-slider"
     >
       {userTaskList.map((userTask: UserTaskListData) => (


### PR DESCRIPTION
Unfortunately, there doesn't seem to be a way to pass through scroll events on Swiper conditionally. See the [Swiper documentation](https://swiperjs.com/swiper-api#mousewheel-control) for more details.

Fixes #252.