### PR TITLE
Fix scrolltotop

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Stack, Container } from '@mui/material';
 import { Global } from '@emotion/react';
 import { Route, Switch, useLocation } from 'react-router-dom';
@@ -41,6 +41,8 @@ function App(): JSX.Element {
   const user = useSelector(getUser);
   const isValidatingToken = useSelector(getIsValidatingToken);
 
+  const contentContainerRef = useRef<null | HTMLDivElement>(null);
+
   const defaultPrivateRouteProps: RouteWithRedirectProps = {
     // Redirect if user is not authenticated
     shouldRedirect: !user,
@@ -74,7 +76,7 @@ function App(): JSX.Element {
           maxWidth={false}
         >
           <GoogleAnalytics />
-          <ScrollToTop />
+          <ScrollToTop container={contentContainerRef.current} />
           <Notifier />
           <Global
             styles={{
@@ -84,7 +86,7 @@ function App(): JSX.Element {
               },
             }}
           />
-          <div className="App-content-container">
+          <div className="App-content-container" ref={contentContainerRef}>
             <Container
               className="column-container"
               disableGutters

--- a/frontend/src/components/common/ScrollToTop.tsx
+++ b/frontend/src/components/common/ScrollToTop.tsx
@@ -1,12 +1,19 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
-export default function ScrollToTop(): null {
+interface Props {
+  container: Element | null;
+}
+
+const ScrollToTop: React.FC<Props> = ({ container }) => {
   const { pathname } = useLocation();
 
   useEffect(() => {
+    container?.scrollTo(0, 0);
     window.scrollTo(0, 0);
   }, [pathname]);
 
   return null;
-}
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
Fixes https://github.com/0dy553y/odyssey/issues/268

To reproduce original issue, try scrolling to bottom in profile page (ensure you have a lot of ongoing challenges). Then, navigate to Explore page and observe that the Explore page is not scrolled to the top