### PR TITLE
Show dot if day has overdue tasks

### DIFF
--- a/frontend/src/components/home/DateCarousel.tsx
+++ b/frontend/src/components/home/DateCarousel.tsx
@@ -123,14 +123,10 @@ const DateCarousel: React.FC<Props> = ({
       >
         {dates.map((date: Date) => (
           <SwiperSlide key={date.toISOString()}>
-            {({ isActive }) => (
-              <DateItem
-                date={date}
-                shouldShowDot={
-                  !isActive && contains(datesWithOverdueTasks, date)
-                }
-              />
-            )}
+            <DateItem
+              date={date}
+              shouldShowDot={contains(datesWithOverdueTasks, date)}
+            />
           </SwiperSlide>
         ))}
       </Swiper>

--- a/frontend/src/components/home/DateCarousel.tsx
+++ b/frontend/src/components/home/DateCarousel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
+  contains,
   getDateFromNowString,
   getDayString,
   getMonthString,
@@ -17,9 +18,14 @@ import './DateCarousel.scss';
 interface Props {
   date: Date;
   setDate: (date: Date) => void;
+  datesWithOverdueTasks: Date[];
 }
 
-const DateCarousel: React.FC<Props> = ({ date, setDate }: Props) => {
+const DateCarousel: React.FC<Props> = ({
+  date,
+  setDate,
+  datesWithOverdueTasks,
+}: Props) => {
   const dateRange = 50;
   const previousIndex = dateRange;
   const [selectedDate, setSelectedDate] = useState(date);
@@ -117,7 +123,10 @@ const DateCarousel: React.FC<Props> = ({ date, setDate }: Props) => {
       >
         {dates.map((date: Date) => (
           <SwiperSlide key={date.toISOString()}>
-            <DateItem date={date} />
+            <DateItem
+              date={date}
+              shouldShowDot={contains(datesWithOverdueTasks, date)}
+            />
           </SwiperSlide>
         ))}
       </Swiper>

--- a/frontend/src/components/home/DateCarousel.tsx
+++ b/frontend/src/components/home/DateCarousel.tsx
@@ -123,10 +123,14 @@ const DateCarousel: React.FC<Props> = ({
       >
         {dates.map((date: Date) => (
           <SwiperSlide key={date.toISOString()}>
-            <DateItem
-              date={date}
-              shouldShowDot={contains(datesWithOverdueTasks, date)}
-            />
+            {({ isActive }) => (
+              <DateItem
+                date={date}
+                shouldShowDot={
+                  !isActive && contains(datesWithOverdueTasks, date)
+                }
+              />
+            )}
           </SwiperSlide>
         ))}
       </Swiper>

--- a/frontend/src/components/home/DateItem.tsx
+++ b/frontend/src/components/home/DateItem.tsx
@@ -19,7 +19,7 @@ const DateItem: React.FC<Props> = ({ date, shouldShowDot }: Props) => {
   return (
     <Stack alignItems="center">
       {shouldShowDot && (
-        <Box sx={{ height: 0, transform: 'translate(0, -1.5em)' }}>
+        <Box sx={{ height: 0, transform: 'translate(0, -1.1em)' }}>
           <Badge color="warning" variant="dot" />
         </Box>
       )}

--- a/frontend/src/components/home/DateItem.tsx
+++ b/frontend/src/components/home/DateItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography } from '@mui/material';
+import { Badge, Box, Stack, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(() => ({
@@ -10,15 +10,23 @@ const useStyles = makeStyles(() => ({
 
 interface Props {
   date: Date;
+  shouldShowDot: boolean;
 }
 
-const DateItem: React.FC<Props> = ({ date }: Props) => {
+const DateItem: React.FC<Props> = ({ date, shouldShowDot }: Props) => {
   const classes = useStyles();
 
   return (
-    <Typography variant="h5" align="center" className={classes.handCursor}>
-      {date.getDate()}
-    </Typography>
+    <Stack alignItems="center">
+      {shouldShowDot && (
+        <Box sx={{ height: 0, transform: 'translate(0, -1.5em)' }}>
+          <Badge color="warning" variant="dot" />
+        </Box>
+      )}
+      <Typography variant="h5" align="center" className={classes.handCursor}>
+        {date.getDate()}
+      </Typography>
+    </Stack>
   );
 };
 

--- a/frontend/src/components/home/UserTaskCard.tsx
+++ b/frontend/src/components/home/UserTaskCard.tsx
@@ -57,6 +57,9 @@ const useStyles = makeStyles(() => ({
     paddingRight: '8px',
     overflowY: 'auto',
     overflowX: 'hidden',
+    // Only allow panning vertical. Specifically, disallow panning horizontal
+    // to minimize conflict with carousel
+    touchAction: 'pan-y',
   },
   padding: {
     height: 15,

--- a/frontend/src/components/home/UserTaskCard.tsx
+++ b/frontend/src/components/home/UserTaskCard.tsx
@@ -56,6 +56,7 @@ const useStyles = makeStyles(() => ({
     // Padding for scrollbar
     paddingRight: '8px',
     overflowY: 'auto',
+    overflowX: 'hidden',
   },
   padding: {
     height: 15,

--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -3,7 +3,10 @@ import { loadUserTasksForDays } from '../../store/usertasks/operations';
 import { batch, useDispatch, useSelector } from 'react-redux';
 import UserTaskCarousel from '../../components/home/UserTaskCarousel';
 import MapDialog from '../../components/map/MapDialog';
-import { getUserTaskListForDay } from '../../store/usertasks/selectors';
+import {
+  getDatesWithOverdueTasks,
+  getUserTaskListForDay,
+} from '../../store/usertasks/selectors';
 import { RootState } from '../../store';
 import { Badge, Box, Grid, IconButton, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
@@ -126,6 +129,7 @@ const HomePage: React.FC = () => {
   )!;
 
   const friendRequests = useSelector(getFriendRequestList);
+  const datesWithOverdueTasks = useSelector(getDatesWithOverdueTasks);
 
   const user = useSelector(getUser);
   if (!user) {
@@ -165,7 +169,11 @@ const HomePage: React.FC = () => {
             </div>
           </Grid>
           <Grid item className={classes.headerCarouselItem}>
-            <DateCarousel date={date} setDate={setDate} />
+            <DateCarousel
+              date={date}
+              setDate={setDate}
+              datesWithOverdueTasks={datesWithOverdueTasks}
+            />
           </Grid>
           <Grid item className={classes.headerNonCarouselItem}>
             <Typography variant="h5">Your Tasks</Typography>

--- a/frontend/src/store/usertasks/selectors.ts
+++ b/frontend/src/store/usertasks/selectors.ts
@@ -1,3 +1,4 @@
+import { isBefore, startOfDay } from 'date-fns';
 import { UserTaskActivityDatum, UserTaskListData } from 'types/usertasks';
 import { getISOStringAtStartOfDay } from '../../utils/date';
 import { RootState } from '../index';
@@ -19,4 +20,28 @@ export function getUserTaskActivityData(
   state: RootState
 ): UserTaskActivityDatum[] {
   return getLocalState(state).userTaskActivityData;
+}
+
+export function getDatesWithOverdueTasks(state: RootState): Date[] {
+  const output: Date[] = [];
+  const today = startOfDay(new Date());
+
+  const tasksByDay = getLocalState(state).tasksByDay;
+
+  Object.entries(tasksByDay).forEach(([isoDate, tasks]) => {
+    const date = new Date(isoDate);
+
+    if (!isBefore(date, today)) {
+      return;
+    }
+
+    for (const task of tasks) {
+      if (!task.completedAt) {
+        output.push(date);
+        break;
+      }
+    }
+  });
+
+  return output;
 }

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,4 +1,4 @@
-import { startOfDay } from 'date-fns';
+import { isEqual, startOfDay } from 'date-fns';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
@@ -52,4 +52,14 @@ export function getDateFromNowString(date: Date): string {
     return currentFormat();
   }
   return dayjs(date).format(currentFormat);
+}
+
+// Date equality does not work as one would expect in Javascript
+export function contains(dates: Date[], dateToFind: Date): boolean {
+  for (const date of dates) {
+    if (isEqual(date, dateToFind)) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
https://github.com/0dy553y/odyssey/issues/112

![image](https://user-images.githubusercontent.com/24363622/140746496-7dcb7c03-fc74-4552-8ff4-1aa20e3396fc.png)

~~Not sure if we still want to show the dot if the date is currently the selected date. Thoughts?~~

Nvm, i'll hide it if the date is currently selected otherwise it looks ugly on mobile


Also, fixes https://github.com/0dy553y/odyssey/issues/252 by disabling horizontal panning in user task description
- To reproduce original issue, try scrolling the user task card in mobile, by dragging from the task description