### PR TITLE
Use white underline for challenge origin links

### DIFF
--- a/frontend/src/pages/challenge/ChallengeDetailsPage.tsx
+++ b/frontend/src/pages/challenge/ChallengeDetailsPage.tsx
@@ -417,7 +417,7 @@ const ChallengeDetailsPage: React.FC = () => {
                   href={challenge.referenceLink}
                   target="_blank"
                   rel="noreferrer"
-                  className={classes.white}
+                  style={{ color: getComplementaryColor(challenge.color) }}
                   underline="always"
                 >
                   Learn more about this challenge

--- a/frontend/src/pages/challenge/ChallengeDetailsPage.tsx
+++ b/frontend/src/pages/challenge/ChallengeDetailsPage.tsx
@@ -65,6 +65,10 @@ const useStyles = makeStyles<Theme>((theme) => ({
   white: {
     color: 'white',
   },
+  whiteUnderline: {
+    textDecoration: 'underline',
+    textDecorationColor: 'white',
+  },
   bold: {
     fontWeight: 'bold',
   },
@@ -417,7 +421,7 @@ const ChallengeDetailsPage: React.FC = () => {
                   href={challenge.referenceLink}
                   target="_blank"
                   rel="noreferrer"
-                  style={{ color: getComplementaryColor(challenge.color) }}
+                  className={`${classes.white} ${classes.whiteUnderline}`}
                   underline="always"
                 >
                   Learn more about this challenge


### PR DESCRIPTION
~~Tried adding the styling to `useStyles` but kept getting a type error. The normal link colour cannot be used because it clashes with some challenge colours.~~

Resolves #324.