### PR TITLE
Rename add friends page to search users page

### DIFF
--- a/frontend/src/pages/friends/FriendsPage.tsx
+++ b/frontend/src/pages/friends/FriendsPage.tsx
@@ -13,7 +13,7 @@ import { useHistory, useParams } from 'react-router-dom';
 import FriendsList from 'components/friendsList';
 import PersonAddAlt1Icon from '@mui/icons-material/PersonAddAlt1';
 import { makeStyles } from '@mui/styles';
-import { ADD_FRIENDS_ROUTE } from '../../routing/routes';
+import { SEARCH_USERS_ROUTE } from '../../routing/routes';
 import { useDispatch, useSelector } from 'react-redux';
 import { getUser } from '../../store/auth/selectors';
 import { RootState } from '../../store';
@@ -79,7 +79,7 @@ const FriendsPage: React.FC = () => {
       {isOwnFriendsPage && (
         <Fab
           className={classes.fab}
-          onClick={() => history.push(ADD_FRIENDS_ROUTE)}
+          onClick={() => history.push(SEARCH_USERS_ROUTE)}
         >
           <PersonAddAlt1Icon />
         </Fab>

--- a/frontend/src/pages/friends/SearchUsersPage.tsx
+++ b/frontend/src/pages/friends/SearchUsersPage.tsx
@@ -66,7 +66,7 @@ const SearchUsersPage: React.FC = () => {
       </AppBar>
 
       <Typography component="h1" variant="h4" style={{ fontFamily: 'Frock' }}>
-        Search Users
+        Search users
       </Typography>
       <TextField
         fullWidth

--- a/frontend/src/pages/friends/SearchUsersPage.tsx
+++ b/frontend/src/pages/friends/SearchUsersPage.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const AddFriendsPage: React.FC = () => {
+const SearchUsersPage: React.FC = () => {
   const classes = useStyles();
   const history = useHistory();
 
@@ -66,7 +66,7 @@ const AddFriendsPage: React.FC = () => {
       </AppBar>
 
       <Typography component="h1" variant="h4" style={{ fontFamily: 'Frock' }}>
-        Add friends
+        Search Users
       </Typography>
       <TextField
         fullWidth
@@ -88,4 +88,4 @@ const AddFriendsPage: React.FC = () => {
   );
 };
 
-export default AddFriendsPage;
+export default SearchUsersPage;

--- a/frontend/src/routing/routes.ts
+++ b/frontend/src/routing/routes.ts
@@ -9,7 +9,7 @@ import CategoryPage from '../pages/category';
 import ChallengeDetailsPage from '../pages/challenge';
 import ExplorePage from '../pages/explore';
 import FeedPage from '../pages/feed';
-import AddFriendsPage from '../pages/friends/AddFriendsPage';
+import SearchUsersPage from '../pages/friends/SearchUsersPage';
 import HomePage from '../pages/home';
 import LoginPage from '../pages/login';
 import { CompletedMapPage, OngoingMapPage } from '../pages/maps';
@@ -27,7 +27,7 @@ export const PROFILE_ROUTE = '/profile';
 export const CATEGORY_ROUTE = '/category';
 export const EDIT_PROFILE_ROUTE = '/edit-profile';
 export const FRIENDS_ROUTE = '/friends';
-export const ADD_FRIENDS_ROUTE = '/add-friends';
+export const SEARCH_USERS_ROUTE = '/search-users';
 export const NOTIFICATIONS_ROUTE = '/notifications';
 export const MEMENTOS_ROUTE = '/mementos';
 export const POSTS_ROUTE = '/posts';
@@ -68,7 +68,7 @@ export const privateRoutes: RouteEntry[] = [
     path: CHALLENGE_ROUTE + '/:challengeId',
     component: ChallengeDetailsPage,
   },
-  { path: ADD_FRIENDS_ROUTE, component: AddFriendsPage, exact: true },
+  { path: SEARCH_USERS_ROUTE, component: SearchUsersPage, exact: true },
   { path: FRIENDS_ROUTE, component: FriendsPage, exact: true },
   { path: FRIENDS_ROUTE + '/:username', component: FriendsPage, exact: true },
   { path: NOTIFICATIONS_ROUTE, component: NotificationsPage, exact: true },


### PR DESCRIPTION
I tried to replicate the same logic from the friend controls in profile for the add friends list, but the UI gets very cluttered, especially on mobile resolutions. :( Anyway, popular social networks like Instagram and Facebook force the user to click into the user's profile before being able to initiate any friend-related functionality, so I hope it's okay?

Kinda resolves #186.